### PR TITLE
Pin the source while we're doing a read beyond safe

### DIFF
--- a/GxHash/GxHash.cs
+++ b/GxHash/GxHash.cs
@@ -187,11 +187,14 @@ public class GxHash
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Vector128<byte> GetPartialVector(ref Vector128<byte> start, int remainingBytes)
+    private static unsafe Vector128<byte> GetPartialVector(ref Vector128<byte> start, int remainingBytes)
     {
-        if (IsReadBeyondSafe(ref start))
+        fixed (Vector128<byte>* pin = &start)
         {
-            return GetPartialVectorUnsafe(ref start, remainingBytes);
+            if (IsReadBeyondSafe(ref start))
+            {
+                return GetPartialVectorUnsafe(ref start, remainingBytes);
+            }
         }
 
         return GetPartialVectorSafe(ref start, remainingBytes);


### PR DESCRIPTION
Pin the source while we're doing a read beyond safe - otherwise GC is allowed to relocate the object after we tested the alignment.

Codegen diff:
- x86_64 https://www.diffchecker.com/A555rSUt/ (for some reason I can't get godbolt to respect `DOTNET_EnableAVX512F=0` but you get the idea)
- ARM64 https://www.diffchecker.com/2iezRn2R/

As pointed out by @KubaZ2 

Also, thank you for providing a C# port, excellent work. It helps with quite a few bottlenecks in production :)
A bit unfortunate that .NET is slept on by so many - you can't really do anything like this on any other GC-based platform.