### PR TITLE
Added .NET 9 and 10

### DIFF
--- a/GxHash.Benchmarks/GxHash.Benchmarks.csproj
+++ b/GxHash.Benchmarks/GxHash.Benchmarks.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <LangVersion>default</LangVersion>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/GxHash.Tests/GxHash.Tests.csproj
+++ b/GxHash.Tests/GxHash.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <LangVersion>default</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <IsPackable>false</IsPackable>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/GxHash.Utils/GxHash.Utils.csproj
+++ b/GxHash.Utils/GxHash.Utils.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <LangVersion>default</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/GxHash/GxHash.csproj
+++ b/GxHash/GxHash.csproj
@@ -12,7 +12,8 @@
       2.0.0: Do partial-first
       1.0.0: First version
     </PackageReleaseNotes>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>default</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
For new versions .The NET performance test shows a slight advantage.

| Method  | Job       | Runtime   | DataSize | Mean          | Error       | StdDev      | Median        | Ratio | RatioSD |
|-------- |---------- |---------- |--------- |--------------:|------------:|------------:|--------------:|------:|--------:|
| Hash128 | .NET 10.0 | .NET 10.0 | 100      |      5.947 ns |   0.0193 ns |   0.0161 ns |      5.950 ns |  0.74 |    0.00 |
| Hash128 | .NET 9.0  | .NET 9.0  | 100      |      6.046 ns |   0.0510 ns |   0.0477 ns |      6.034 ns |  0.75 |    0.01 |
| Hash128 | .NET 8.0  | .NET 8.0  | 100      |      8.054 ns |   0.0213 ns |   0.0177 ns |      8.056 ns |  1.00 |    0.00 |
|         |           |           |          |               |             |             |               |       |         |
| Hash128 | .NET 10.0 | .NET 10.0 | 512      |     11.437 ns |   0.0304 ns |   0.0284 ns |     11.444 ns |  0.98 |    0.00 |
| Hash128 | .NET 9.0  | .NET 9.0  | 512      |     11.445 ns |   0.0426 ns |   0.0356 ns |     11.432 ns |  0.98 |    0.01 |
| Hash128 | .NET 8.0  | .NET 8.0  | 512      |     11.711 ns |   0.0569 ns |   0.0532 ns |     11.702 ns |  1.00 |    0.01 |
|         |           |           |          |               |             |             |               |       |         |
| Hash128 | .NET 10.0 | .NET 10.0 | 1048576  | 23,217.324 ns |  76.0723 ns |  59.3923 ns | 23,208.047 ns |  0.97 |    0.03 |
| Hash128 | .NET 9.0  | .NET 9.0  | 1048576  | 23,243.060 ns | 113.7648 ns |  88.8201 ns | 23,238.173 ns |  0.97 |    0.03 |
| Hash128 | .NET 8.0  | .NET 8.0  | 1048576  | 23,882.591 ns | 470.9727 ns | 799.7475 ns | 23,291.519 ns |  1.00 |    0.05 |
|         |           |           |          |               |             |             |               |       |         |
| Hash128 | .NET 10.0 | .NET 10.0 | 2097152  | 47,063.060 ns | 606.1934 ns | 506.1990 ns | 46,891.156 ns |  1.00 |    0.01 |
| Hash128 | .NET 9.0  | .NET 9.0  | 2097152  | 46,987.460 ns | 255.2322 ns | 250.6722 ns | 46,943.216 ns |  1.00 |    0.01 |
| Hash128 | .NET 8.0  | .NET 8.0  | 2097152  | 47,211.359 ns | 165.0324 ns | 128.8465 ns | 47,173.157 ns |  1.00 |    0.00 |